### PR TITLE
Configure plugin logger instead of root logger

### DIFF
--- a/src/pytest_loop/__init__.py
+++ b/src/pytest_loop/__init__.py
@@ -96,8 +96,8 @@ class PyTest_Loop:
 	def __init__(self, config: Config):
 		# turn debug prints on only if "-vv" or more passed
 		level = logging.DEBUG if config.option.verbose > 1 else logging.INFO
-		logging.basicConfig(level=level)
 		self.logger = logging.getLogger(self.name)
+		self.logger.setLevel(level)
 
 	@hookspec(firstresult=True)
 	def pytest_runtestloop(self, session: Session) -> bool:


### PR DESCRIPTION
Summary
=======

This change prevents the `pytest-loop` plugin from configuring the root logger via `logging.basicConfig(level=...)` which can unintentionally enable DEBUG-level logging across the entire pytest process when the plugin is loaded.

What I changed
--------------
- Removed the call to `logging.basicConfig(...)` in `pytest_loop.__init__`.
- Set the level only on the plugin's own logger (`logging.getLogger('pytest-loop')`) using `setLevel(...)`.

Why
---
Plugins must not configure the root logger because it affects global behavior for other code and for the test runner. The previous behavior caused DEBUG messages to be printed when users only set `--log-format` or didn't explicitly request debug output.
